### PR TITLE
added minimal redis cluster support (no autoreconnect)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,22 @@ The server(s) to connect to, as either URIs or ``(host, port)`` tuples.
 Defaults to ``['localhost', 6379]``. Pass multiple hosts to enable sharding,
 but note that changing the host list will lose some sharded data.
 
+It's also possible to connect to a Redis cluster using Sentinels::
+
+    CHANNEL_LAYERS = {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {
+                "hosts": [{
+                    "sentinels": [("sentinel-1", 26379), ("sentinel-2", 26379)],
+                    "master_name": "cluster-1",
+                    "connection_params": {"db": 42},
+                }]
+            },
+        },
+    }
+
+
 ``prefix``
 ~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ test_requires = crypto_requires + [
     "pytest-asyncio~=0.8",
     "async_generator~=1.8",
     "async-timeout~=2.0",
+    "asynctest~=0.12",
 ]
 
 


### PR DESCRIPTION
This should be enough to connect to a cluster. There is no auto-retry, but it's not really needed in our case since React app will reconnect when needed.

It also makes it possible to use a standalone Redis and specify db number using the dict format for a shard:

    [{'address': ('redis-1', 3306), 'db': 10}]